### PR TITLE
Fixed Trip details spacing bug, and integrated LabeledTextFields

### DIFF
--- a/Scoop.xcodeproj/project.pbxproj
+++ b/Scoop.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2C12DEB629C64D11003D6683 /* PostRideTripDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C12DEB529C64D11003D6683 /* PostRideTripDetailsViewController.swift */; };
 		2C1D968929F89C1000065C78 /* VerifyPhoneNumberViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1D968829F89C1000065C78 /* VerifyPhoneNumberViewController.swift */; };
 		2C2015DF2AB4CFAB0065C436 /* ShiftedRightTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2015DE2AB4CFAB0065C436 /* ShiftedRightTextField.swift */; };
+		2C3294842AD7351800F6B1B4 /* PickerOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3294832AD7351800F6B1B4 /* PickerOptions.swift */; };
 		2C42B51E290F12B400D053A3 /* Sen-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 2C42B51D290F12B400D053A3 /* Sen-Regular.ttf */; };
 		2C42B521290F767600D053A3 /* Rambla-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 2C42B520290F767600D053A3 /* Rambla-Regular.ttf */; };
 		2C5672FE29CBE5EB001E37FB /* Prompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5672FD29CBE5EB001E37FB /* Prompts.swift */; };
@@ -97,6 +98,7 @@
 		2C12DEB529C64D11003D6683 /* PostRideTripDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRideTripDetailsViewController.swift; sourceTree = "<group>"; };
 		2C1D968829F89C1000065C78 /* VerifyPhoneNumberViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPhoneNumberViewController.swift; sourceTree = "<group>"; };
 		2C2015DE2AB4CFAB0065C436 /* ShiftedRightTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShiftedRightTextField.swift; sourceTree = "<group>"; };
+		2C3294832AD7351800F6B1B4 /* PickerOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerOptions.swift; sourceTree = "<group>"; };
 		2C42B51D290F12B400D053A3 /* Sen-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Sen-Regular.ttf"; sourceTree = "<group>"; };
 		2C42B520290F767600D053A3 /* Rambla-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Rambla-Regular.ttf"; sourceTree = "<group>"; };
 		2C5672FD29CBE5EB001E37FB /* Prompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prompts.swift; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 				C845953727ED01A400D2C7F0 /* Utilities */,
 				C8A544C227D18D5400132ACC /* Keys.swift */,
 				2C67E4FB29945E5E00195BB5 /* Constants.swift */,
+				2C3294832AD7351800F6B1B4 /* PickerOptions.swift */,
 				C8A5449A27D185BF00132ACC /* Info.plist */,
 				C8A5449727D185BF00132ACC /* LaunchScreen.storyboard */,
 				C8A5449527D185BF00132ACC /* Assets.xcassets */,
@@ -648,6 +651,7 @@
 				2C991EBE28E0B2E7006301D9 /* LocationViewController.swift in Sources */,
 				C8A544BD27D18D0200132ACC /* HomeViewController.swift in Sources */,
 				2C85C53929E5B85300A0C387 /* Request.swift in Sources */,
+				2C3294842AD7351800F6B1B4 /* PickerOptions.swift in Sources */,
 				C8EF10CE27E50BFA00642B40 /* OnboardingViewController.swift in Sources */,
 				2C991EBC28E0B2E7006301D9 /* DepartureSearchViewController.swift in Sources */,
 				C8CB5E8E28182CC3007FB8A8 /* HomeTableViewHeader.swift in Sources */,

--- a/Scoop/Controller/Onboarding/AboutYouViewController.swift
+++ b/Scoop/Controller/Onboarding/AboutYouViewController.swift
@@ -20,8 +20,8 @@ class AboutYouViewController: OnboardingViewController {
     private let pronounsPicker = UIPickerView()
     private let yearPicker = UIPickerView()
     
-    private let pronouns = PickerOptions.pronouns
-    private let years = PickerOptions.years
+    private let pronouns = PickerOptions.scooped.pronouns
+    private let years = PickerOptions.scooped.years
 
     // MARK: - Lifecycle Functions
     

--- a/Scoop/Controller/Onboarding/AboutYouViewController.swift
+++ b/Scoop/Controller/Onboarding/AboutYouViewController.swift
@@ -20,8 +20,8 @@ class AboutYouViewController: OnboardingViewController {
     private let pronounsPicker = UIPickerView()
     private let yearPicker = UIPickerView()
     
-    private let pronouns = ["He/Him", "She/Her", "They/Them", "Other"]
-    private let years = ["Freshman", "Sophomore", "Junior", "Senior", "Grad Student"]
+    private let pronouns = PickerOptions.pronouns
+    private let years = PickerOptions.years
 
     // MARK: - Lifecycle Functions
     

--- a/Scoop/Controller/Profile/EditProfileViewController.swift
+++ b/Scoop/Controller/Profile/EditProfileViewController.swift
@@ -12,22 +12,24 @@ class EditProfileViewController: UIViewController {
     
     // MARK: - Views
     
-    private let classTextField = UITextField()
-    private let classPickerView = UIPickerView()
+    private let classTextField = LabeledTextField()
+    private let classPicker = UIPickerView()
     private let emailButton = UIButton()
-    private let hometownTextField = UITextField()
+    private let hometownTextField = LabeledTextField()
+    private let imagePicker = UIImagePickerController()
     private let imageView = UIView()
     private let musicSlider = UISlider()
     private let musicTicks = UIButton()
     private let musicView = UIView()
-    private let nameTextField = UITextField()
+    private let nameTextField = LabeledTextField()
     private let phoneButton = UIButton()
-    private let phoneNumTextField = UITextField()
+    private let phoneNumTextField = LabeledTextField()
     private let profileImageView = UIImageView()
-    private let pronounsTextField = UITextField()
-    private let snackTextField = UITextField()
-    private let songTextField = UITextField()
-    private let stopTextField = UITextField()
+    private let pronounsPicker = UIPickerView()
+    private let pronounsTextField = LabeledTextField()
+    private let snackTextField = LabeledTextField()
+    private let songTextField = LabeledTextField()
+    private let stopTextField = LabeledTextField()
     private let talkativeSlider = UISlider()
     private let talkativeView = UIView()
     private let talkativeTicks = UIButton()
@@ -58,6 +60,9 @@ class EditProfileViewController: UIViewController {
     private let leadingTrailingInset = 32
     private let textFieldHeight = 56
     
+    private let pronouns = PickerOptions.pronouns
+    private let years = PickerOptions.years
+    
     // MARK: - Lifecycle Functions
 
     override func viewDidLoad() {
@@ -67,11 +72,13 @@ class EditProfileViewController: UIViewController {
         setupHeader()
         setupScrollView()
         setupMainStackView()
+        setupImagePicker()
         setupImageView()
         setupAboutYouStackView()
         setupPreferredContactStackView()
         setupPreferencesStackView()
         setupFavoritesStackView()
+        setupTextFields()
     }
     
     override func viewDidLayoutSubviews() {
@@ -100,16 +107,16 @@ class EditProfileViewController: UIViewController {
             profileImageView.image = UIImage.emptyImage
         }
         
-        nameTextField.text = "\(user.firstName) \(user.lastName)"
-        pronounsTextField.text = user.pronouns
-        hometownTextField.text = hometown
-        classTextField.text = user.grade
-        phoneNumTextField.text = user.phoneNumber
+        nameTextField.setText(str: "\(user.firstName) \(user.lastName)")
+        pronounsTextField.setText(str: user.pronouns)
+        hometownTextField.setText(str: hometown)
+        classTextField.setText(str: user.grade)
+        phoneNumTextField.setText(str: user.phoneNumber)
         talkativeSlider.setValue(talkative, animated: false)
         musicSlider.setValue(music, animated: false)
-        snackTextField.text = snack
-        songTextField.text = song
-        stopTextField.text = stop
+        snackTextField.setText(str: snack)
+        songTextField.setText(str: song)
+        stopTextField.setText(str: stop)
     }
     
     required init?(coder: NSCoder) {
@@ -201,6 +208,7 @@ class EditProfileViewController: UIViewController {
         uploadPhotoButton.backgroundColor = UIColor.gray
         uploadPhotoButton.contentMode = .scaleAspectFill
         uploadPhotoButton.clipsToBounds = true
+        uploadPhotoButton.addTarget(self, action: #selector(updateProfileImage), for: .touchUpInside)
         imageView.addSubview(uploadPhotoButton)
         
         uploadPhotoButton.snp.makeConstraints { make in
@@ -209,6 +217,9 @@ class EditProfileViewController: UIViewController {
             make.leading.equalTo(profileImageView).offset(85)
             make.trailing.equalTo(profileImageView).offset(-9)
         }
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(updateProfileImage))
+        imageView.addGestureRecognizer(tapGesture)
     }
 
     private func setupAboutYouStackView() {
@@ -223,12 +234,7 @@ class EditProfileViewController: UIViewController {
             make.top.equalTo(imageView.snp.bottom).offset(25)
         }
         
-        nameTextField.attributedPlaceholder = NSAttributedString(
-            string: "Name",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.mutedGrey])
-        nameTextField.font = UIFont.bodyNormal
-        nameTextField.textColor = UIColor.black
-        nameTextField.borderStyle = .roundedRect
+        nameTextField.setup(title: "Name")
         aboutYouStackView.addArrangedSubview(nameTextField)
         
         nameTextField.snp.makeConstraints { make in
@@ -236,12 +242,11 @@ class EditProfileViewController: UIViewController {
             make.height.equalTo(textFieldHeight)
         }
         
-        pronounsTextField.attributedPlaceholder = NSAttributedString(
-            string: "Pronouns",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.mutedGrey])
-        pronounsTextField.font = UIFont.bodyNormal
-        pronounsTextField.textColor = UIColor.black
-        pronounsTextField.borderStyle = .roundedRect
+        pronounsPicker.delegate = self
+        pronounsPicker.dataSource = self
+        
+        pronounsTextField.setup(title: "Pronouns")
+        pronounsTextField.textField.inputView = pronounsPicker
         aboutYouStackView.addArrangedSubview(pronounsTextField)
         
         pronounsTextField.snp.makeConstraints { make in
@@ -249,12 +254,7 @@ class EditProfileViewController: UIViewController {
             make.height.equalTo(textFieldHeight)
         }
         
-        hometownTextField.attributedPlaceholder = NSAttributedString(
-            string: "Hometown",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.mutedGrey])
-        hometownTextField.font = UIFont.bodyNormal
-        hometownTextField.textColor = UIColor.black
-        hometownTextField.borderStyle = .roundedRect
+        hometownTextField.setup(title: "Hometown")
         aboutYouStackView.addArrangedSubview(hometownTextField)
         
         hometownTextField.snp.makeConstraints { make in
@@ -262,12 +262,11 @@ class EditProfileViewController: UIViewController {
             make.height.equalTo(textFieldHeight)
         }
         
-        classTextField.attributedPlaceholder = NSAttributedString(
-            string: "Class Year",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.mutedGrey])
-        classTextField.font = UIFont.bodyNormal
-        classTextField.textColor = UIColor.black
-        classTextField.borderStyle = .roundedRect
+        classPicker.delegate = self
+        classPicker.dataSource = self
+        
+        classTextField.setup(title: "Class")
+        classTextField.textField.inputView = classPicker
         aboutYouStackView.addArrangedSubview(classTextField)
         
         classTextField.snp.makeConstraints { make in
@@ -338,23 +337,15 @@ class EditProfileViewController: UIViewController {
             emailButton.isSelected.toggle()
             phoneButton.isSelected.toggle()
 
-            if emailButton.isSelected {
-                phoneNumTextField.isHidden = true
-            } else {
-                phoneNumTextField.isHidden = false
-            }
+            phoneNumTextField.isHidden = emailButton.isSelected
         }
 
         emailButton.addAction(selectContactAction, for: .touchUpInside)
         phoneButton.addAction(selectContactAction, for: .touchUpInside)
         
+        phoneNumTextField.setup(title: "Phone", placeholder: "000-000-0000")
         phoneNumTextField.isHidden = true
-        phoneNumTextField.font = UIFont.bodyNormal
-        phoneNumTextField.textColor = UIColor.offBlack
-        phoneNumTextField.placeholder = "000-000-0000"
-        phoneNumTextField.borderStyle = .roundedRect
-        phoneNumTextField.font = UIFont.bodyNormal
-        phoneNumTextField.keyboardType = .phonePad
+        phoneNumTextField.textField.keyboardType = .phonePad
         preferredContactStackView.addArrangedSubview(phoneNumTextField)
 
         phoneNumTextField.snp.makeConstraints { make in
@@ -522,12 +513,7 @@ class EditProfileViewController: UIViewController {
             make.leading.trailing.equalToSuperview().inset(leadingTrailingInset)
         }
         
-        snackTextField.attributedPlaceholder = NSAttributedString(
-            string: "Roadtrip snack",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.mutedGrey])
-        snackTextField.font = UIFont.bodyNormal
-        snackTextField.textColor = UIColor.black
-        snackTextField.borderStyle = .roundedRect
+        snackTextField.setup(title: "Roadtrip snack")
         favoritesStackView.addArrangedSubview(snackTextField)
         
         snackTextField.snp.makeConstraints { make in
@@ -535,12 +521,7 @@ class EditProfileViewController: UIViewController {
             make.height.equalTo(textFieldHeight)
         }
         
-        songTextField.attributedPlaceholder = NSAttributedString(
-            string: "Roadtrip song",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.mutedGrey])
-        songTextField.font = UIFont.bodyNormal
-        songTextField.textColor = UIColor.black
-        songTextField.borderStyle = .roundedRect
+        songTextField.setup(title: "Roadtrip song")
         favoritesStackView.addArrangedSubview(songTextField)
         
         songTextField.snp.makeConstraints { make in
@@ -548,12 +529,7 @@ class EditProfileViewController: UIViewController {
             make.height.equalTo(textFieldHeight)
         }
         
-        stopTextField.attributedPlaceholder = NSAttributedString(
-            string: "Roadtrip stop",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.mutedGrey])
-        stopTextField.font = UIFont.bodyNormal
-        stopTextField.textColor = UIColor.black
-        stopTextField.borderStyle = .roundedRect
+        stopTextField.setup(title: "Roadtrip stop")
         favoritesStackView.addArrangedSubview(stopTextField)
         
         stopTextField.snp.makeConstraints { make in
@@ -562,22 +538,47 @@ class EditProfileViewController: UIViewController {
         }
     }
     
+    private func setupTextFields() {
+        [nameTextField, pronounsTextField, hometownTextField, classTextField, phoneNumTextField, snackTextField, songTextField, stopTextField].forEach { textField in
+            textField.textField.delegate = self
+            textField.hidesLabel(isHidden: false)
+        }
+    }
+    
+    private func setupImagePicker() {
+        imagePicker.delegate = self
+        imagePicker.allowsEditing = true
+        imagePicker.mediaTypes = ["public.image"]
+        imagePicker.sourceType = .photoLibrary
+    }
+    
+    
+    
     // MARK: - Helper Functions
     
+    @objc private func updateProfileImage(_ sender: UITapGestureRecognizer) {
+        present(imagePicker, animated: true)
+    }
+    
+    private func convertImage (image: UIImage) -> String {
+        let base64 = image.jpegData(compressionQuality: 0.5)?.base64EncodedString() ?? ""
+        return "data:image/png;base64," + base64
+    }
+    
     private func updateUser() {
-        let name = nameTextField.text?.split(separator: " ")
+        let name = nameTextField.getText()?.split(separator: " ")
         let firstName = String(name?[0] ?? "")
         let lastName = String(name?[1...].joined(separator: " ") ?? "")
-        let grade = classTextField.text
-        let pronouns = pronounsTextField.text
-        let phoneNumber = phoneNumTextField.text
+        let grade = classTextField.getText()
+        let pronouns = pronounsTextField.getText()
+        let phoneNumber = phoneNumTextField.getText()
         
-        hometown = hometownTextField.text
+        hometown = hometownTextField.getText()
         talkative = talkativeSlider.value
         music = musicSlider.value
-        snack = snackTextField.text
-        song = songTextField.text
-        stop = stopTextField.text
+        snack = snackTextField.getText()
+        song = songTextField.getText()
+        stop = stopTextField.getText()
         
         var userAnswers: [UserAnswer] = []
                 
@@ -623,3 +624,98 @@ class EditProfileViewController: UIViewController {
     }
     
 }
+
+// MARK: - UITextFieldDelegate
+
+extension EditProfileViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        return !(textField == classTextField || textField == pronounsTextField)
+    }
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        if let onboardingTextField = textField as? OnboardingTextField {
+            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+                associatedView.labeledTextField(isSelected: true)
+                associatedView.hidesLabel(isHidden: false)
+            }
+        }
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        if let onboardingTextField = textField as? OnboardingTextField {
+            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+                associatedView.labeledTextField(isSelected: false)
+                if textField.text?.isEmpty ?? true {
+                    associatedView.hidesLabel(isHidden: true)
+                }
+            }
+        }
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(true)
+    }
+}
+
+// MARK: - UIPickerViewDelegate
+
+extension EditProfileViewController: UIPickerViewDelegate {
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        if pickerView == pronounsPicker {
+            return pronouns[row]
+        } else if pickerView == classPicker {
+            return years[row]
+        }
+        
+        return nil
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        if pickerView == pronounsPicker {
+            pronounsTextField.textField.text = pronouns[row]
+        } else if pickerView == classPicker {
+            classTextField.textField.text = years[row]
+        }
+    }
+}
+
+// MARK: - UIPickerViewDataSource
+
+extension EditProfileViewController: UIPickerViewDataSource {
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        if pickerView == pronounsPicker {
+            return pronouns.count
+        } else if pickerView == classPicker {
+            return years.count
+        }
+        return 0
+    }
+}
+
+// MARK: - UIImagePickerControllerDelegate
+
+extension EditProfileViewController: UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        
+        guard let image = info[.editedImage] as? UIImage else {
+            dismiss(animated: true, completion: nil)
+            return
+        }
+        
+        profileImageView.image = image
+
+        dismiss(animated: true, completion: nil)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        dismiss(animated: true, completion: nil)
+    }
+}
+

--- a/Scoop/Controller/Profile/EditProfileViewController.swift
+++ b/Scoop/Controller/Profile/EditProfileViewController.swift
@@ -60,8 +60,8 @@ class EditProfileViewController: UIViewController {
     private let leadingTrailingInset = 32
     private let textFieldHeight = 56
     
-    private let pronouns = PickerOptions.pronouns
-    private let years = PickerOptions.years
+    private let pronouns = PickerOptions.scooped.pronouns
+    private let years = PickerOptions.scooped.years
     
     // MARK: - Lifecycle Functions
 
@@ -552,17 +552,10 @@ class EditProfileViewController: UIViewController {
         imagePicker.sourceType = .photoLibrary
     }
     
-    
-    
     // MARK: - Helper Functions
     
     @objc private func updateProfileImage(_ sender: UITapGestureRecognizer) {
         present(imagePicker, animated: true)
-    }
-    
-    private func convertImage (image: UIImage) -> String {
-        let base64 = image.jpegData(compressionQuality: 0.5)?.base64EncodedString() ?? ""
-        return "data:image/png;base64," + base64
     }
     
     private func updateUser() {
@@ -628,26 +621,25 @@ class EditProfileViewController: UIViewController {
 // MARK: - UITextFieldDelegate
 
 extension EditProfileViewController: UITextFieldDelegate {
+    
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         return !(textField == classTextField || textField == pronounsTextField)
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        if let onboardingTextField = textField as? OnboardingTextField {
-            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
-                associatedView.labeledTextField(isSelected: true)
-                associatedView.hidesLabel(isHidden: false)
-            }
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
+            associatedView.hidesLabel(isHidden: false)
         }
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        if let onboardingTextField = textField as? OnboardingTextField {
-            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
-                associatedView.labeledTextField(isSelected: false)
-                if textField.text?.isEmpty ?? true {
-                    associatedView.hidesLabel(isHidden: true)
-                }
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: false)
+            if textField.text?.isEmpty ?? true {
+                associatedView.hidesLabel(isHidden: true)
             }
         }
     }
@@ -655,6 +647,7 @@ extension EditProfileViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.endEditing(true)
     }
+    
 }
 
 // MARK: - UIPickerViewDelegate
@@ -678,6 +671,7 @@ extension EditProfileViewController: UIPickerViewDelegate {
             classTextField.textField.text = years[row]
         }
     }
+    
 }
 
 // MARK: - UIPickerViewDataSource
@@ -694,8 +688,10 @@ extension EditProfileViewController: UIPickerViewDataSource {
         } else if pickerView == classPicker {
             return years.count
         }
+        
         return 0
     }
+    
 }
 
 // MARK: - UIImagePickerControllerDelegate
@@ -717,5 +713,6 @@ extension EditProfileViewController: UINavigationControllerDelegate, UIImagePick
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
         dismiss(animated: true, completion: nil)
     }
+    
 }
 

--- a/Scoop/Controller/Ride Posting/PostRideSummaryViewController.swift
+++ b/Scoop/Controller/Ride Posting/PostRideSummaryViewController.swift
@@ -82,9 +82,9 @@ class PostRideSummaryViewController: PostRideViewController {
         let screenSize = UIScreen.main.bounds
         
         stackView.axis = .vertical
-        stackView.distribution = .fill
-        stackView.alignment = .leading
-        stackView.spacing = 25
+        stackView.distribution = .fillProportionally
+        stackView.alignment = .top
+        stackView.spacing = 24
         view.addSubview(stackView)
         
         stackView.snp.makeConstraints { make in
@@ -310,23 +310,32 @@ class PostRideSummaryViewController: PostRideViewController {
     }
     
     private func setupDetailsInfo() {
+        let containerView = UIView()
         let ride = currentRide
         
         detailsLabel.text = "DETAILS"
-        stackView.addArrangedSubview(detailsLabel)
+        containerView.addSubview(detailsLabel)
         
-        stackView.setCustomSpacing(1, after: detailsLabel)
+        detailsLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview()
+        }
         
         detailsTextView.text = ride.description
         detailsTextView.font = .systemFont(ofSize: 16)
         detailsTextView.textColor = .black
         detailsTextView.isEditable = false
         detailsTextView.isSelectable = false
-        stackView.addArrangedSubview(detailsTextView)
+        containerView.addSubview(detailsTextView)
 
         detailsTextView.snp.makeConstraints { make in
+            make.top.equalTo(detailsLabel.snp.bottom).offset(6)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        stackView.addArrangedSubview(containerView)
+        
+        containerView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(60)
         }
     }
     

--- a/Scoop/Controller/TripDetailsViewController.swift
+++ b/Scoop/Controller/TripDetailsViewController.swift
@@ -82,9 +82,9 @@ class TripDetailsViewController: UIViewController {
         let screenSize = UIScreen.main.bounds
         
         stackView.axis = .vertical
-        stackView.distribution = .fill
-        stackView.alignment = .leading
-        stackView.spacing = 25
+        stackView.distribution = .fillProportionally
+        stackView.alignment = .top
+        stackView.spacing = 24
         view.addSubview(stackView)
         
         stackView.snp.makeConstraints { make in
@@ -98,7 +98,7 @@ class TripDetailsViewController: UIViewController {
         setUpLocationInfo()
         setUpDateInfo()
         setUpTravelerInfo()
-        setUpDetailsInfo()
+        setupDetailsInfo()
     }
     
     private func setUpDriverInfo() {
@@ -311,22 +311,34 @@ class TripDetailsViewController: UIViewController {
         }
     }
     
-    private func setUpDetailsInfo() {
+    private func setupDetailsInfo() {
         guard let ride = currentRide else { return }
         
+        let containerView = UIView()
+        
         detailsLabel.text = "DETAILS"
-        stackView.addArrangedSubview(detailsLabel)
+        containerView.addSubview(detailsLabel)
+        
+        detailsLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview()
+        }
         
         detailsTextView.text = ride.description
         detailsTextView.font = .systemFont(ofSize: 16)
         detailsTextView.textColor = .black
         detailsTextView.isEditable = false
         detailsTextView.isSelectable = false
-        stackView.addArrangedSubview(detailsTextView)
+        containerView.addSubview(detailsTextView)
 
         detailsTextView.snp.makeConstraints { make in
+            make.top.equalTo(detailsLabel.snp.bottom).offset(6)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        stackView.addArrangedSubview(containerView)
+        
+        containerView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(70)
         }
     }
     

--- a/Scoop/Supporting/PickerOptions.swift
+++ b/Scoop/Supporting/PickerOptions.swift
@@ -9,7 +9,9 @@ import Foundation
 
 class PickerOptions {
     
-    static let pronouns = ["He/Him", "She/Her", "They/Them", "Other"]
-    static let years = ["Freshman", "Sophomore", "Junior", "Senior", "Grad Student"]
+    static let scooped = PickerOptions()
+    
+    let pronouns = ["He/Him", "She/Her", "They/Them", "Other"]
+    let years = ["Freshman", "Sophomore", "Junior", "Senior", "Grad Student"]
     
 }

--- a/Scoop/Supporting/PickerOptions.swift
+++ b/Scoop/Supporting/PickerOptions.swift
@@ -1,0 +1,15 @@
+//
+//  PickerOptions.swift
+//  Scoop
+//
+//  Created by Richie Sun on 10/11/23.
+//
+
+import Foundation
+
+class PickerOptions {
+    
+    static let pronouns = ["He/Him", "She/Her", "They/Them", "Other"]
+    static let years = ["Freshman", "Sophomore", "Junior", "Senior", "Grad Student"]
+    
+}

--- a/Scoop/Supporting/Utilities/Extension+UIImage.swift
+++ b/Scoop/Supporting/Utilities/Extension+UIImage.swift
@@ -16,4 +16,9 @@ extension UIImage {
     static let sliderThumb = UIImage(named: "SliderThumb")
     static let sliderTicks = UIImage(named: "SliderTicks")
     
+    func imageToB64(compression: CGFloat) -> String {
+        let base64 = self.jpegData(compressionQuality: compression)?.base64EncodedString() ?? ""
+        return "data:image/png;base64," + base64
+    }
+    
 }

--- a/Scoop/View/LabeledTextField.swift
+++ b/Scoop/View/LabeledTextField.swift
@@ -53,7 +53,7 @@ class LabeledTextField: UIView {
     private func setupLabel(title: String) {
         nameLabel.text = " \(title) "
         nameLabel.font = .systemFont(ofSize: 12)
-        nameLabel.textColor = .black
+        nameLabel.textColor = .mutedGrey
         nameLabel.backgroundColor = .white
         nameLabel.isHidden = true
         addSubview(nameLabel)
@@ -72,7 +72,7 @@ class LabeledTextField: UIView {
             textField.layer.borderWidth = 2
             textField.layer.borderColor = UIColor.scoopDarkGreen.cgColor
         } else {
-            nameLabel.textColor = .black
+            nameLabel.textColor = .mutedGrey
             textField.layer.borderWidth = 1
             textField.layer.borderColor = UIColor.black.cgColor
         }
@@ -80,6 +80,14 @@ class LabeledTextField: UIView {
     
     func hidesLabel(isHidden: Bool) {
         nameLabel.isHidden = isHidden
+    }
+    
+    func setText(str: String?) {
+        textField.text = str
+    }
+    
+    func getText() -> String? {
+        return textField.text
     }
     
 }


### PR DESCRIPTION
## Overview

- Fixed trip details spacing bug
- Updated EditProfileViewController to include custom textFields



## Changes Made

- Addressed https://github.com/cuappdev/scoop-ios/issues/66
- Integrated LabeledTextField to all textFields in EditProfileVC and implemented corresponding delegates
- Implemented imagePicker Views and UIPickerViews for pronouns and year
- Fixed boolean error with email/ phone button option

## Next Steps (delete if not applicable)

- Implement validation for all textFields

## Screenshots (delete if not applicable)

<img src = https://github.com/cuappdev/scoop-ios/assets/105038960/51fb6b90-49ed-4477-bca3-98ebf585008b width = "300px" height = "auto"><img src = https://github.com/cuappdev/scoop-ios/assets/105038960/ad5875a1-75d7-4987-ac12-97f0c836d5f8 width = "300px" height = "auto">


