### PR TITLE
Implemented validation for EditProfileVC

### DIFF
--- a/Scoop/Controller/Profile/EditProfileViewController.swift
+++ b/Scoop/Controller/Profile/EditProfileViewController.swift
@@ -658,19 +658,32 @@ class EditProfileViewController: UIViewController {
     }
 
     @objc private func saveEdit() {
-        let name = nameTextField.getText()?.split(separator: " ")
-        let firstName = String(name?[0] ?? "")
-        let lastName = String(name?[1...].joined(separator: " ") ?? "")
-        let grade = classTextField.getText()
-        let pronouns = pronounsTextField.getText()
-        let phoneNumber = phoneNumTextField.getText()
+        guard let name = nameTextField.getText(), !name.isEmpty,
+              let grade = classTextField.getText(), !grade.isEmpty,
+              let pronouns = pronounsTextField.getText(), !pronouns.isEmpty,
+              let hometown = hometownTextField.getText(), !hometown.isEmpty,
+              let snack = snackTextField.getText(), !snack.isEmpty,
+              let song = songTextField.getText(), !song.isEmpty,
+              let stop = stopTextField.getText(), !stop.isEmpty else {
+                  print("Error: Please complete all fields")
+                  return
+              }
 
-        hometown = hometownTextField.getText()
+        let phoneNumber = phoneNumTextField.getText()
         talkative = talkativeSlider.value
         music = musicSlider.value
-        snack = snackTextField.getText()
-        song = songTextField.getText()
-        stop = stopTextField.getText()
+        self.hometown = hometown
+        self.snack = snack
+        self.song = song
+        self.stop = stop
+
+        guard let nameArray = nameTextField.getText()?.split(separator: " "), nameArray.count == 2 else {
+            print("Error: Name field does not contain first and last name")
+            return
+        }
+
+        let firstName = String(nameArray[0])
+        let lastName = String(nameArray[1])
 
         updateAuthenticatedUserRequest(firstName: firstName, lastName: lastName, grade: grade, phoneNumber: phoneNumber, pronouns: pronouns, prompts: getUserAnswers())
 

--- a/Scoop/Controller/Profile/EditProfileViewController.swift
+++ b/Scoop/Controller/Profile/EditProfileViewController.swift
@@ -837,11 +837,6 @@ extension EditProfileViewController: UITextFieldDelegate {
             }
         }
 
-        var fields: [String] = []
-        [classTextField, hometownTextField, nameTextField, phoneNumTextField, pronounsTextField, snackTextField, songTextField, stopTextField].forEach { textField in
-            fields.append(textField.textField.text ?? "")
-        }
-
         setSaveButtonColor(disabled: !textFieldsComplete())
     }
 

--- a/Scoop/Controller/Profile/EditProfileViewController.swift
+++ b/Scoop/Controller/Profile/EditProfileViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class EditProfileViewController: UIViewController {
     
     // MARK: - Views
-    
+
     private let cancelButton = UIButton()
     private let classTextField = LabeledTextField()
     private let classPicker = UIPickerView()
@@ -704,6 +704,27 @@ class EditProfileViewController: UIViewController {
         present(imagePicker, animated: true)
     }
 
+    private func setSaveButtonColor(disabled: Bool) {
+        saveButton.layer.opacity = disabled ? 0.5 : 1
+    }
+
+    private func textFieldsComplete() -> Bool {
+        var complete = true
+
+        [nameTextField, classTextField, pronounsTextField, hometownTextField, snackTextField, songTextField, stopTextField].forEach { textField in
+            guard let field = textField.getText()?.trimmingCharacters(in: .whitespacesAndNewlines), !field.isEmpty else {
+                complete = false
+                return
+            }
+        }
+
+        guard let name = nameTextField.getText()?.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: " "), name.count == 2 else {
+            return false
+        }
+
+        return complete
+    }
+
     private func getUserAnswers() -> [UserAnswer] {
         var userAnswers: [UserAnswer] = []
 
@@ -806,6 +827,8 @@ extension EditProfileViewController: UITextFieldDelegate {
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
+        textField.text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+
         if let onboardingTextField = textField as? OnboardingTextField,
            let associatedView = onboardingTextField.associatedView as? LabeledTextField {
             associatedView.labeledTextField(isSelected: false)
@@ -813,6 +836,13 @@ extension EditProfileViewController: UITextFieldDelegate {
                 associatedView.hidesLabel(isHidden: true)
             }
         }
+
+        var fields: [String] = []
+        [classTextField, hometownTextField, nameTextField, phoneNumTextField, pronounsTextField, snackTextField, songTextField, stopTextField].forEach { textField in
+            fields.append(textField.textField.text ?? "")
+        }
+
+        setSaveButtonColor(disabled: !textFieldsComplete())
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {


### PR DESCRIPTION
## Overview

Implemented validation for the edit profile page.



## Changes Made

### Edit Profile Page

- In `EditProfileViewController`, modified `saveEdit` so that the user is unable to save their edits if any of the following apply:
  - Any of the text fields are left blank.
  - The name field is less than or greater than two words long (must only include first and last name).
  - (Temporary) Error statements in terminal for these two cases. Will be deleted after new text fields are implemented.
- Once exiting a text field, trims the extra whitespace the user may have inputted into the text fields.
- Once exiting a text field, checks whether the text fields are completed (using the same conditions as above) with `textFieldsComplete`, and if so, changes the opacity of the button to its respective state using `setSaveButtonColor`.



## Test Coverage

- Did manual testing to ensure functionality.



## Screenshots

<details>

  <summary>Validation</summary>

  https://github.com/cuappdev/scoop-ios/assets/118781810/22d21886-a17e-4a57-a49a-152cee5fcc6a

</details>