### PR TITLE
Text field refactor/richie

### DIFF
--- a/Scoop/Controller/Onboarding/AboutYouViewController.swift
+++ b/Scoop/Controller/Onboarding/AboutYouViewController.swift
@@ -30,18 +30,24 @@ class AboutYouViewController: OnboardingViewController {
         view.backgroundColor = .white
         setupTitle(name: "About you")
         
-        nextAction = UIAction { _ in
+        nextAction = UIAction { [self] _ in
             guard let navCtrl = self.navigationController else {
                 return
+            }
+
+            [nameTextField, pronounsTextField, hometownTextField, yearTextField].forEach { textField in
+                if (textField.textField.text ?? "").isEmpty {
+                    textField.displayError()
+                }
             }
             
             guard let name = self.nameTextField.textField.text, !name.isEmpty,
                   let pronouns = self.pronounsTextField.textField.text, !pronouns.isEmpty,
                   let hometown = self.hometownTextField.textField.text, !hometown.isEmpty,
                   let year = self.yearTextField.textField.text, !year.isEmpty else {
-                      self.presentErrorAlert(title: "Error", message: "Please complete all fields.")
-                      return
-                  }
+                return
+            }
+
             NetworkManager.shared.currentUser.pronouns = pronouns
             NetworkManager.shared.currentUser.grade = year
             let hometownTrimmed = hometown.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -65,9 +71,6 @@ class AboutYouViewController: OnboardingViewController {
         var stackViewMultiplier = 0.20
         let leadingTrailingInset = 32
         let screenSize = UIScreen.main.bounds
-        let textFieldBorderWidth = 1.0
-        let textFieldCornerRadius = 4.0
-        let textFieldFont = UIFont(name: "SFPro", size: 16)
         let textFieldHeight = 56
         
         if screenSize.height < 2000 {
@@ -150,25 +153,23 @@ class AboutYouViewController: OnboardingViewController {
 extension AboutYouViewController: UITextFieldDelegate {
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        return !(textField == yearTextField || textField == pronounsTextField)
+        return !(textField == yearTextField.textField || textField == pronounsTextField.textField)
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        if let onboardingTextField = textField as? OnboardingTextField {
-            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
-                associatedView.labeledTextField(isSelected: true)
-                associatedView.hidesLabel(isHidden: false)
-            }
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
+            associatedView.hidesLabel(isHidden: false)
         }
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        if let onboardingTextField = textField as? OnboardingTextField {
-            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
-                associatedView.labeledTextField(isSelected: false)
-                if textField.text?.isEmpty ?? true {
-                    associatedView.hidesLabel(isHidden: true)
-                }
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: false)
+            if textField.text?.isEmpty ?? true {
+                associatedView.hidesLabel(isHidden: true)
             }
         }
         
@@ -182,6 +183,13 @@ extension AboutYouViewController: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.endEditing(true)
+    }
+
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
+        }
     }
     
 }

--- a/Scoop/Controller/Onboarding/FavoritesViewController.swift
+++ b/Scoop/Controller/Onboarding/FavoritesViewController.swift
@@ -23,24 +23,28 @@ class FavoritesViewController: OnboardingViewController {
         view.backgroundColor = .white
         setupTitle(name: "Favorites")
         
-        nextAction = UIAction { _ in
-            guard let navCtrl = self.navigationController else { return }
-    
-            guard let snack = self.snackTextField.textField.text, !snack.isEmpty,
-                  let song = self.songTextField.textField.text, !song.isEmpty,
-                  let stop = self.stopTextField.textField.text, !stop.isEmpty else {
-                      self.presentErrorAlert(title: "Error", message: "Please complete all fields.")
-                      
-                      return
-                  }
+        nextAction = UIAction { [self] _ in
+            guard let navCtrl = navigationController else { return }
+            
+            [snackTextField, songTextField, stopTextField].forEach { textField in
+                if (textField.textField.text ?? "").isEmpty {
+                    textField.displayError()
+                }
+            }
+            
+            guard let snack = snackTextField.textField.text, !snack.isEmpty,
+                  let song = songTextField.textField.text, !song.isEmpty,
+                  let stop = stopTextField.textField.text, !stop.isEmpty else {
+                return
+            }
             
             let snackTrimmed = snack.trimmingCharacters(in: .whitespacesAndNewlines)
             let songTrimmed = song.trimmingCharacters(in: .whitespacesAndNewlines)
             let stopTrimmed = stop.trimmingCharacters(in: .whitespacesAndNewlines)
-            self.addPrompt(name: "Snack", placeholder: "Chips", answer: snackTrimmed)
-            self.addPrompt(name: "Song", placeholder: "Favorite Song", answer: songTrimmed)
-            self.addPrompt(name: "Stop", placeholder: "Gates Hall", answer: stopTrimmed)
-            self.delegate?.didTapNext(navCtrl, nextViewController: nil)
+            addPrompt(name: "Snack", placeholder: "Chips", answer: snackTrimmed)
+            addPrompt(name: "Song", placeholder: "Favorite Song", answer: songTrimmed)
+            addPrompt(name: "Stop", placeholder: "Gates Hall", answer: stopTrimmed)
+            delegate?.didTapNext(navCtrl, nextViewController: nil)
         }
         
         setupTitleLines()
@@ -53,9 +57,6 @@ class FavoritesViewController: OnboardingViewController {
     // MARK: - Setup View Functions
     
     private func setupStackView() {
-        let textFieldBorderWidth = 1.0
-        let textFieldCornerRadius = 4.0
-        let textFieldFont = UIFont(name: "SFPro", size: 16)
         let leadingTrailingInset = 32
         let textFieldHeight = 56
         
@@ -105,21 +106,19 @@ class FavoritesViewController: OnboardingViewController {
 extension FavoritesViewController: UITextFieldDelegate {
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        if let onboardingTextField = textField as? OnboardingTextField {
-            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
-                associatedView.labeledTextField(isSelected: true)
-                associatedView.hidesLabel(isHidden: false)
-            }
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
+            associatedView.hidesLabel(isHidden: false)
         }
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        if let onboardingTextField = textField as? OnboardingTextField {
-            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
-                associatedView.labeledTextField(isSelected: false)
-                if textField.text?.isEmpty ?? true {
-                    associatedView.hidesLabel(isHidden: true)
-                }
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: false)
+            if textField.text?.isEmpty ?? true {
+                associatedView.hidesLabel(isHidden: true)
             }
         }
         
@@ -129,6 +128,13 @@ extension FavoritesViewController: UITextFieldDelegate {
         }
         
         setNextButtonColor(disabled: !textFieldsComplete(texts: responses))
+    }
+
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
+        }
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Scoop/Controller/Onboarding/PreferredContactViewController.swift
+++ b/Scoop/Controller/Onboarding/PreferredContactViewController.swift
@@ -46,7 +46,7 @@ class PreferredContactViewController: OnboardingViewController {
             }
             
             guard let phoneNumber = self.numberTextField.textField.text, self.validateNumber(value: phoneNumber) else {
-                self.presentErrorAlert(title: "Error", message: "Please enter a valid phone number.")
+                self.numberTextField.displayError()
                 return
             }
             
@@ -137,7 +137,7 @@ class PreferredContactViewController: OnboardingViewController {
         
         numberTextField.isHidden = true
         numberTextField.delegate = self
-        numberTextField.setup(title: "Phone", placeholder: "000-000-0000")
+        numberTextField.setup(title: "Phone", placeholder: "000-000-0000", error: "Please enter a valid phone number")
         numberTextField.textField.keyboardType = .phonePad
         view.addSubview(numberTextField)
         
@@ -172,31 +172,32 @@ extension PreferredContactViewController: UITextFieldDelegate {
     }
     
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        if textField == numberTextField.textField {
-            self.setNextButtonColor(disabled: !self.validateNumber(value: self.numberTextField.textField.text ?? ""))
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
         }
+
+        setNextButtonColor(disabled: !validateNumber(value: textField.text ?? ""))
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        if let onboardingTextField = textField as? OnboardingTextField {
-            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
-                associatedView.labeledTextField(isSelected: true)
-                associatedView.hidesLabel(isHidden: false)
-            }
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
+            associatedView.hidesLabel(isHidden: false)
         }
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        if let onboardingTextField = textField as? OnboardingTextField {
-            if let associatedView = onboardingTextField.associatedView as? LabeledTextField {
-                associatedView.labeledTextField(isSelected: false)
-                if textField.text?.isEmpty ?? true {
-                    associatedView.hidesLabel(isHidden: true)
-                }
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: false)
+            if textField.text?.isEmpty ?? true {
+                associatedView.hidesLabel(isHidden: true)
             }
         }
     }
-    
+
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.endEditing(true)
     }

--- a/Scoop/SearchRidesViewController.swift
+++ b/Scoop/SearchRidesViewController.swift
@@ -11,15 +11,12 @@ import UIKit
 class SearchRidesViewController: UIViewController {
     
     // MARK: - Views
-    
-    private let arrivalLabel = UILabel()
-    private let arrivalTextField = ImageTextField()
+
+    private let arrivalTextField = LabeledTextField(isShifted: true)
     private let calendarIconImageView = UIImageView()
     private let datePicker = UIDatePicker()
-    private let departureDateLabel = UILabel()
-    private let departureDateTextField = OnboardingTextField()
-    private let departureLabel = UILabel()
-    private let departureTextField = ImageTextField()
+    private let departureDateTextField = LabeledTextField()
+    private let departureTextField = LabeledTextField(isShifted: true)
     private let findTripsButton = UIButton()
     private let stackView = UIStackView()
     
@@ -40,7 +37,6 @@ class SearchRidesViewController: UIViewController {
         setupStackView()
         setupLocationTextFields()
         setupButton()
-        setupLabels()
     }
     
     // MARK: - Setup View Functions
@@ -98,33 +94,43 @@ class SearchRidesViewController: UIViewController {
         let textFieldBorderWidth = 1.0
         let textFieldCornerRadius = 4.0
         let textFieldHeight = 56
-        
-        departureTextField.textField.textColor = UIColor.scooped.offBlack
+
         departureTextField.textField.delegate = self
-        departureTextField.textField.attributedPlaceholder = NSAttributedString(
-            string: "Departure location",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.scooped.offBlack])
+        departureTextField.setup(title: "Departure location")
+
+        // Sets up the icon inside the text field.
+        let iconContainer = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 15))
+        let departureIcon = UIImageView(frame: CGRect(x: 10, y: -2.5, width: 20, height: 20))
+        departureIcon.image = UIImage(named: "locationIcon")
+        departureIcon.contentMode = .scaleAspectFit
+        iconContainer.addSubview(departureIcon)
+
+        departureTextField.textField.leftView = iconContainer;
+        departureTextField.textField.leftViewMode = UITextField.ViewMode.always
+        departureTextField.textField.leftViewMode = .always
         departureTextField.textField.addTarget(self, action: #selector(presentDepartureSearch), for: .touchDown)
-        departureTextField.imageView.image = UIImage(named: "locationIcon")
         stackView.addArrangedSubview(departureTextField)
-        
-        arrivalTextField.textField.textColor = UIColor.scooped.offBlack
+
         arrivalTextField.textField.delegate = self
-        arrivalTextField.textField.attributedPlaceholder = NSAttributedString(
-            string: "Arrival location",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.scooped.offBlack])
-        arrivalTextField.textField.addTarget(self, action: #selector(presentArrivalSearch), for: .touchDown)
-        arrivalTextField.imageView.image = UIImage(named: "destinationIcon")
-        stackView.addArrangedSubview(arrivalTextField)
+        arrivalTextField.setup(title: "Arrival location")
         
-        departureDateTextField.textColor = UIColor.scooped.offBlack
+        // Sets up the icon inside the text field.
+        let iconContainer2 = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: 15))
+        let arrivalIcon = UIImageView(frame: CGRect(x: 10, y: -2.5, width: 20, height: 20))
+        arrivalIcon.image = UIImage(named: "destinationIcon")
+        arrivalIcon.contentMode = .scaleAspectFit
+        iconContainer2.addSubview(arrivalIcon)
+
+        arrivalTextField.textField.leftView = iconContainer2;
+        arrivalTextField.textField.leftViewMode = .always
+        arrivalTextField.textField.addTarget(self, action: #selector(presentArrivalSearch), for: .touchDown)
+        stackView.addArrangedSubview(arrivalTextField)
+
         departureDateTextField.delegate = self
-        departureDateTextField.attributedPlaceholder = NSAttributedString(
-            string: "Departure date",
-            attributes: [NSAttributedString.Key.foregroundColor: UIColor.scooped.offBlack])
-        departureDateTextField.inputView = datePicker
-        departureDateTextField.addTarget(self, action: #selector(updateDate), for: .touchDown)
-        departureDateTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingDidEnd)
+        departureDateTextField.setup(title: "Departure date")
+        departureDateTextField.textField.inputView = datePicker
+        departureDateTextField.textField.addTarget(self, action: #selector(updateDate), for: .touchDown)
+        departureDateTextField.textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingDidEnd)
         stackView.addArrangedSubview(departureDateTextField)
         
         datePicker.datePickerMode = .date
@@ -136,15 +142,12 @@ class SearchRidesViewController: UIViewController {
         view.addSubview(calendarIconImageView)
         
         calendarIconImageView.snp.makeConstraints { make in
-            make.centerY.equalTo(departureDateTextField)
+            make.centerY.equalTo(departureDateTextField.textField)
             make.trailing.equalTo(departureDateTextField).inset(12)
             make.size.equalTo(24)
         }
         
         [departureTextField, arrivalTextField, departureDateTextField].forEach { text in
-            text.layer.borderWidth = textFieldBorderWidth
-            text.layer.borderColor = UIColor.scooped.textFieldBorderColor.cgColor
-            text.layer.cornerRadius = textFieldCornerRadius
             text.snp.makeConstraints { make in
                 make.leading.trailing.equalToSuperview()
                 make.height.equalTo(textFieldHeight)
@@ -170,78 +173,41 @@ class SearchRidesViewController: UIViewController {
         }
     }
     
-    private func setupLabels() {
-        let labelLeading = 10
-        let labelTop = 8
-        
-        [departureLabel, arrivalLabel, departureDateLabel].forEach { label in
-            label.font = .systemFont(ofSize: 12)
-            label.textColor = UIColor.scooped.textFieldBorderColor
-            label.backgroundColor = .white
-            label.textAlignment = .center
-            label.isHidden = true
-            view.addSubview(label)
-        }
-        
-        departureLabel.text = "Departure location"
-        departureLabel.snp.makeConstraints { make in
-            make.top.equalTo(departureTextField).inset(-labelTop)
-            make.leading.equalTo(departureTextField).inset(labelLeading)
-            make.height.equalTo(16)
-            make.width.equalTo(120)
-        }
-        
-        arrivalLabel.text = "Arrival location"
-        arrivalLabel.snp.makeConstraints { make in
-            make.top.equalTo(arrivalTextField).inset(-labelTop)
-            make.leading.equalTo(arrivalTextField).inset(labelLeading)
-            make.height.equalTo(16)
-            make.width.equalTo(99)
-        }
-        
-        departureDateLabel.text = "Departure date"
-        departureDateLabel.snp.makeConstraints { make in
-            make.top.equalTo(departureDateTextField).inset(-labelTop)
-            make.leading.equalTo(departureDateTextField).inset(labelLeading)
-            make.height.equalTo(16)
-            make.width.equalTo(99)
-        }
-    }
-    
     // MARK: - Helper Functions
     
     @objc private func presentDepartureSearch() {
         let depatureVC = DepartureSearchViewController()
         depatureVC.delegate = self
         navigationController?.pushViewController(depatureVC, animated: true)
-        departureLabel.isHidden = false
     }
 
     @objc private func presentArrivalSearch() {
         let arrivalVC = ArrivalSearchViewController()
         arrivalVC.delegate = self
         navigationController?.pushViewController(arrivalVC, animated: true)
-        arrivalLabel.isHidden = false
     }
     
     @objc private func updateDate() {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .medium
-        departureDateTextField.text = dateFormatter.string(from: datePicker.date)
-        departureDateLabel.isHidden = false
+        departureDateTextField.textField.text = dateFormatter.string(from: datePicker.date)
     }
     
     @objc private func presentMatches() {
         findTripsButton.isEnabled = false
+
+        [departureTextField, arrivalTextField, departureDateTextField].forEach { textField in
+            if (textField.textField.text ?? "").isEmpty {
+                textField.displayError()
+            }
+        }
+
         findTripsButton.backgroundColor = UIColor.scooped.disabledGreen
         guard let departure = self.departureTextField.textField.text, !departure.isEmpty,
               let arrival = self.arrivalTextField.textField.text, !arrival.isEmpty,
               let departureID = departurePlace?.placeID,
-              let dateString = departureDateTextField.text, !dateString.isEmpty,
-              let arrivalID = arrivalPlace?.placeID else {
-                  presentErrorAlert(title: "Error", message: "Please complete all fields.")
-                  return
-              }
+              let dateString = departureDateTextField.textField.text, !dateString.isEmpty,
+              let arrivalID = arrivalPlace?.placeID else { return }
         
         tripDate = formatDate(dateToConvert: self.datePicker.date)
         NetworkManager.shared.searchLocation(depatureDate: tripDate, startLocation: departureID, endLocation: arrivalID) { [weak self] response in
@@ -264,7 +230,7 @@ class SearchRidesViewController: UIViewController {
               !text1.isEmpty,
               let text2 = arrivalTextField.textField.text,
               !text2.isEmpty,
-              let text3 = departureDateTextField.text,
+              let text3 = departureDateTextField.textField.text,
               !text3.isEmpty else {
             findTripsButton.backgroundColor = UIColor.scooped.disabledGreen
             return
@@ -289,6 +255,35 @@ extension SearchRidesViewController: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         return false
     }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
+            associatedView.hidesLabel(isHidden: false)
+        }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: false)
+            if textField.text?.isEmpty ?? true {
+                associatedView.hidesLabel(isHidden: true)
+            }
+        }
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(true)
+    }
+
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        if let onboardingTextField = textField as? OnboardingTextField,
+           let associatedView = onboardingTextField.associatedView as? LabeledTextField {
+            associatedView.labeledTextField(isSelected: true)
+        }
+    }
     
 }
 
@@ -301,10 +296,14 @@ extension SearchRidesViewController: SearchInitialViewControllerDelegate {
             departurePlace = location
             departureTextField.textField.text = location.name
             self.textFieldDidChange(sender: departureTextField.textField)
+            departureTextField.hidesLabel(isHidden: false)
+            departureTextField.labeledTextField(isSelected: false)
         } else if viewController is ArrivalSearchViewController {
             arrivalPlace = location
             arrivalTextField.textField.text = location.name
             self.textFieldDidChange(sender: arrivalTextField.textField)
+            arrivalTextField.hidesLabel(isHidden: false)
+            arrivalTextField.labeledTextField(isSelected: false)
         }
     }
 

--- a/Scoop/SearchRidesViewController.swift
+++ b/Scoop/SearchRidesViewController.swift
@@ -194,7 +194,6 @@ class SearchRidesViewController: UIViewController {
     }
     
     @objc private func presentMatches() {
-        findTripsButton.isEnabled = false
 
         [departureTextField, arrivalTextField, departureDateTextField].forEach { textField in
             if (textField.textField.text ?? "").isEmpty {
@@ -208,6 +207,8 @@ class SearchRidesViewController: UIViewController {
               let departureID = departurePlace?.placeID,
               let dateString = departureDateTextField.textField.text, !dateString.isEmpty,
               let arrivalID = arrivalPlace?.placeID else { return }
+
+        findTripsButton.isEnabled = false
         
         tripDate = formatDate(dateToConvert: self.datePicker.date)
         NetworkManager.shared.searchLocation(depatureDate: tripDate, startLocation: departureID, endLocation: arrivalID) { [weak self] response in

--- a/Scoop/Supporting/Utilities/Extension+UIColor.swift
+++ b/Scoop/Supporting/Utilities/Extension+UIColor.swift
@@ -17,6 +17,8 @@ extension UIColor {
         let darkerGreen = UIColor(red: 0, green: 0.42, blue: 0.33, alpha: 1)
         let disabledGreen = UIColor(red: 219/255, green: 229/255, blue: 223/255, alpha: 1)
         let disabledGrey = UIColor(red: 136/255, green: 153/255, blue: 155/255, alpha: 1)
+        let errorRed = UIColor(red: 186/255, green: 26/255, blue: 26/255, alpha: 1)
+        let errorRed2 = UIColor(red: 105/255, green: 0/255, blue: 5/255, alpha: 1)
         let labelGray = UIColor(red: 112/255, green: 112/255, blue: 112/255, alpha: 1)
         let linearGradient = UIColor(red: 1, green: 1, blue: 1, alpha: 1)
         let mutedGrey = UIColor(red: 106/255, green: 115/255, blue: 125/255, alpha: 1)

--- a/Scoop/View/ImageTextField.swift
+++ b/Scoop/View/ImageTextField.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class ImageTextField: UIView {
-    
+
     let textField = ShiftedRightTextField()
     let imageView = UIImageView()
     
@@ -30,10 +30,10 @@ class ImageTextField: UIView {
             make.size.equalTo(20)
         }
     }
-    
+
     private func setupInfoLabel() {
         addSubview(textField)
-        
+
         textField.snp.makeConstraints { make in
             make.leading.equalToSuperview().inset(5)
             make.trailing.equalToSuperview()
@@ -41,10 +41,10 @@ class ImageTextField: UIView {
             make.height.equalTo(56)
         }
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
 }
 

--- a/Scoop/View/LabeledTextField.swift
+++ b/Scoop/View/LabeledTextField.swift
@@ -12,20 +12,40 @@ class LabeledTextField: UIView {
     weak var delegate: UITextFieldDelegate?
     
     // MARK: - Views
-    
+
+    let errorLabel = UILabel()
     private let nameLabel = UILabel()
-    let textField = OnboardingTextField()
-    
+    var textField = OnboardingTextField()
+
+    // MARK: - Initializers
+
+    init(isShifted: Bool = false) {
+        if isShifted {
+            textField = OnboardingTextField(isShifted: true)
+        }
+
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     // MARK: - Setup Views
     
-    func setup(title: String, placeholder: String? = nil) {
+    func setup(title: String, placeholder: String? = nil, error: String? = nil) {
         var text = title
+        var errorText = "Please complete this field."
         if let placeholder = placeholder {
             text = placeholder
         }
+
+        if let error = error {
+            errorText = error
+        }
         
         setupTextField(placeholder: text)
-        setupLabel(title: title)
+        setupLabels(title: title, error: errorText)
     }
     
     private func setupTextField(placeholder: String) {
@@ -38,19 +58,19 @@ class LabeledTextField: UIView {
         textField.backgroundColor = .white
         textField.layer.borderWidth = 1
         textField.layer.cornerRadius = 4
-        textField.layer.borderColor = UIColor.black.cgColor
+        textField.layer.borderColor = UIColor.scooped.mutedGrey.cgColor
         textField.delegate = self.delegate
         textField.isUserInteractionEnabled = true
         textField.associatedView = self
         addSubview(textField)
         
         textField.snp.makeConstraints { make in
-            make.leading.trailing.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
             make.height.equalTo(56)
         }
     }
     
-    private func setupLabel(title: String) {
+    private func setupLabels(title: String, error: String) {
         nameLabel.text = " \(title) "
         nameLabel.font = .systemFont(ofSize: 12)
         nameLabel.textColor = UIColor.scooped.mutedGrey
@@ -62,20 +82,53 @@ class LabeledTextField: UIView {
             make.leading.equalToSuperview().inset(16)
             make.centerY.equalTo(textField.snp.top)
         }
+
+        errorLabel.text = error
+        errorLabel.font = .systemFont(ofSize: 12)
+        errorLabel.textColor = UIColor.scooped.errorRed
+        errorLabel.backgroundColor = .white
+        errorLabel.isHidden = true
+        addSubview(errorLabel)
+
+        errorLabel.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.top.equalTo(textField.snp.bottom).offset(5)
+            make.bottom.equalToSuperview()
+        }
     }
     
     // MARK: - Helper Functions
     
     func labeledTextField(isSelected: Bool) {
+        errorLabel.isHidden = true
+        
         if isSelected {
             nameLabel.textColor = UIColor.scooped.scoopDarkGreen
             textField.layer.borderWidth = 2
             textField.layer.borderColor = UIColor.scooped.scoopDarkGreen.cgColor
         } else {
-            nameLabel.textColor = UIColor.scooped.mutedGrey
             textField.layer.borderWidth = 1
-            textField.layer.borderColor = UIColor.black.cgColor
+
+            if let text = textField.text, !text.isEmpty {
+                nameLabel.textColor = UIColor.scooped.offBlack
+                textField.layer.borderColor = UIColor.black.cgColor
+            } else {
+                nameLabel.textColor = UIColor.scooped.mutedGrey
+                textField.layer.borderColor = UIColor.scooped.mutedGrey.cgColor
+            }
         }
+    }
+
+    func displayError() {
+        nameLabel.textColor = UIColor.scooped.errorRed2
+        textField.layer.borderColor = UIColor.scooped.errorRed.cgColor
+        errorLabel.isHidden = false
+    }
+
+    func hideError() {
+        nameLabel.textColor = (textField.text ?? "").isEmpty ? UIColor.scooped.mutedGrey : UIColor.scooped.offBlack
+        textField.layer.borderColor = (textField.text ?? "").isEmpty ? UIColor.scooped.mutedGrey.cgColor : UIColor.black.cgColor
+        errorLabel.isHidden = true
     }
     
     func hidesLabel(isHidden: Bool) {

--- a/Scoop/View/LabeledTextView.swift
+++ b/Scoop/View/LabeledTextView.swift
@@ -19,22 +19,17 @@ class LabeledTextView: UIView {
     // MARK: - Setup Views
 
     func setup(title: String, placeholder: String? = nil) {
-        var text = title
-        if let placeholder = placeholder {
-            text = placeholder
-        }
-
-        setupTextField(placeholder: text)
+        setupTextField()
         setupLabel(title: title)
     }
 
-    private func setupTextField(placeholder: String) {
+    private func setupTextField() {
         textView.font = .systemFont(ofSize: 16)
         textView.textColor = .black
         textView.backgroundColor = .white
         textView.layer.borderWidth = 1
         textView.layer.cornerRadius = 4
-        textView.layer.borderColor = UIColor.black.cgColor
+        textView.layer.borderColor = UIColor.scooped.mutedGrey.cgColor
         textView.delegate = self.delegate
         textView.isUserInteractionEnabled = true
         textView.isSelectable = true
@@ -65,13 +60,20 @@ class LabeledTextView: UIView {
 
     func labeledTextView(isSelected: Bool) {
         if isSelected {
+            nameLabel.isHidden = false
             nameLabel.textColor = UIColor.scooped.scoopDarkGreen
             textView.layer.borderWidth = 2
             textView.layer.borderColor = UIColor.scooped.scoopDarkGreen.cgColor
         } else {
-            nameLabel.textColor = UIColor.scooped.mutedGrey
             textView.layer.borderWidth = 1
-            textView.layer.borderColor = UIColor.black.cgColor
+
+            if let text = textView.text, !text.isEmpty {
+                nameLabel.textColor = UIColor.black
+                textView.layer.borderColor = UIColor.black.cgColor
+            } else {
+                nameLabel.textColor = UIColor.scooped.mutedGrey
+                textView.layer.borderColor = UIColor.scooped.mutedGrey.cgColor
+            }
         }
     }
 

--- a/Scoop/View/OnboardingTextField.swift
+++ b/Scoop/View/OnboardingTextField.swift
@@ -8,11 +8,29 @@
 import UIKit
 
 class OnboardingTextField: UITextField {
-    
-    let padding = UIEdgeInsets(top: 18.5, left: 16, bottom: 18.5, right: 16)
+
+    // MARK: - Data
+
+    var padding = UIEdgeInsets(top: 18.5, left: 16, bottom: 18.5, right: 16)
     
     weak var associatedView: UIView?
 
+    // MARK: - Initializers
+
+    init(isShifted: Bool = false) {
+        if isShifted {
+            padding = UIEdgeInsets(top: 12, left: 38, bottom: 12, right: 60)
+        }
+
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - TextField Bounds
+    
     override open func textRect(forBounds bounds: CGRect) -> CGRect {
         return bounds.inset(by: padding)
     }


### PR DESCRIPTION
## Overview

- Refactored all textFields to add additional functionality
- Removed all error pop up views with error messages below each textField
- Changed textField color change based on interaction

## Changes Made

### LabeledTextField Added Finite States: (View FSM Below)
1. Untouched: No label shown, border is muted grey color and displays placeholder text, border width 1px
2. Currently Editing: Show label in scoopedDarkGreen, border is scoopedDarkGreen color and border width 2px
3. Finished Editing: 
      a. Has Text: Show label in black, border is black color and border width 1px
      b. No Text: Show label in mutedGrey, border is mutedGrey color and displays placeholder text, border width 1px
4. Error state: Show label in errorRed, border is errorRed color and border width 1px, and displays proper error message below textField


Refactored and updated interactivity for textFields in the following VCs
- AboutYouViewController
- PreferredContactViewController
- PreferencesViewController
- FavoritesViewController
- InitialPostRideViewController
- PostRideTripDetailsViewController
- SearchRidesViewController

## Screenshots (delete if not applicable)
![IMG_2428](https://github.com/cuappdev/scoop-ios/assets/105038960/d86a437c-2085-490e-8505-cddf6c045afd)

<img src = https://github.com/cuappdev/scoop-ios/assets/105038960/59e5da87-3a77-40b7-bb88-38466402916c width = "300px" height = "auto">
<img src = https://github.com/cuappdev/scoop-ios/assets/105038960/0d325d94-9d2f-4d35-8054-2a88b51bea66 width = "300px" height = "auto">


Error States:
<img src = https://github.com/cuappdev/scoop-ios/assets/105038960/026fe5d0-398f-4f1e-b482-bf9040311778 width = "300px" height = "auto"><img src = https://github.com/cuappdev/scoop-ios/assets/105038960/270e87ed-d3c3-4a77-b4c6-a0df7590d275 width = "300px" height = "auto">
